### PR TITLE
Fix latest data fields

### DIFF
--- a/Software/server_project/db/base.py
+++ b/Software/server_project/db/base.py
@@ -20,6 +20,7 @@ from db.models import (
     Spo2Record,
     LocationRecord,
     LatestLocation,
+    LatestHeartRate,
     CaloriesByHeartRate,
     CaloriesByAccelerometer,
     CaloriesDaily,
@@ -53,6 +54,10 @@ class BaseService:
         lat_spo2 = raw.get("latest_spo2")
         if lat_spo2:
             user.latest_spo2 = Spo2Record(**lat_spo2)
+        # Latest heart rate
+        lat_hr = raw.get("latest_heart_rate")
+        if lat_hr:
+            user.latest_heart_rate = LatestHeartRate(**lat_hr)
 
         # GPS history
         for ts, rec in raw.get("gps", {}).items():

--- a/Software/server_project/db/firebase_manager.py
+++ b/Software/server_project/db/firebase_manager.py
@@ -61,19 +61,18 @@ def update_spo2(user_id: str, timestamp: str, percentage: float) -> None:
 
 
 def update_latest_in4_hr(user_id: str, bpm: float) -> None:
-    """
-    Update the latest SpO2 value.
-    """
-    path = f"users/{user_id}/latest_in4/bpm"
-    get_reference(path).set(bpm)
+    """Update the latest heart rate value."""
+    # Other parts of the application read this value from
+    # `latest_heart_rate`, so store it under the same path.
+    path = f"users/{user_id}/latest_heart_rate"
+    get_reference(path).set({"bpm": bpm})
 
 
 def update_latest_in4_spo2(user_id: str, percentage: float) -> None:
-    """
-    Update the latest SpO2 value.
-    """
-    path = f"users/{user_id}/latest_in4/percentage"
-    get_reference(path).set(percentage)
+    """Update the latest SpO2 value."""
+    # Keep the storage format consistent with generated test data
+    path = f"users/{user_id}/latest_spo2"
+    get_reference(path).set({"percentage": percentage})
 
 
 def update_gps(user_id: str, timestamp: str, latitude: float, longitude: float, altitude: float) -> None:

--- a/Software/server_project/db/models.py
+++ b/Software/server_project/db/models.py
@@ -35,6 +35,14 @@ class LatestLocation:
         return asdict(self)
 
 @dataclass
+class LatestHeartRate:
+    bpm: float
+    timestamp: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+@dataclass
 class SleepRecord:
     start_time: str
     end_time: str
@@ -80,6 +88,7 @@ class UserData:
     calories_by_heart_rate: Dict[str, CaloriesByHeartRate] = field(default_factory=dict)
     spo2: Dict[str, Spo2Record] = field(default_factory=dict)
     latest_spo2: Optional[Spo2Record] = None
+    latest_heart_rate: Optional[LatestHeartRate] = None
     calorise_by_accelerometer: Dict[str, CaloriesByAccelerometer] = field(default_factory=dict)
     gps: Dict[str, LocationRecord] = field(default_factory=dict)
     latest_location: Optional[LatestLocation] = None
@@ -96,6 +105,7 @@ class UserData:
             "calories_by_heart_rate": {k: v.to_dict() for k, v in self.calories_by_heart_rate.items()},
             "spo2": {k: v.to_dict() for k, v in self.spo2.items()},
             "latest_spo2": self.latest_spo2.to_dict() if self.latest_spo2 else {},
+            "latest_heart_rate": self.latest_heart_rate.to_dict() if self.latest_heart_rate else {},
             "calorise_by_accelerometer": {k: v.to_dict() for k, v in self.calorise_by_accelerometer.items()},
             "gps": {k: v.to_dict() for k, v in self.gps.items()},
             "latest_location": self.latest_location.to_dict() if self.latest_location else {},

--- a/Software/wearable_app/lib/core/utils/process_data.dart
+++ b/Software/wearable_app/lib/core/utils/process_data.dart
@@ -18,6 +18,7 @@ class ProcessDataService {
 
     final user = await _loadUser(userId);
     user.heartRate[timestamp] = HeartRateEntry(bpm: bpm);
+    user.latestHeartRate = LatestHeartRate(bpm: bpm, timestamp: timestamp);
 
     final weight = (data['weight_kg'] as num?)?.toDouble() ?? 70.0;
     final age = (data['age'] as num?)?.toDouble() ?? 30.0;
@@ -159,6 +160,12 @@ class ProcessDataService {
   Future<LatestSpO2> getLatestSpO2(String userId) async {
     final user = await getUserModel(userId);
     return user.latestSpO2;
+  }
+
+  /// Lấy nhịp tim mới nhất
+  Future<LatestHeartRate> getLatestHeartRate(String userId) async {
+    final user = await getUserModel(userId);
+    return user.latestHeartRate;
   }
 
   /// Lấy calories từ accelerometer cho ngày

--- a/Software/wearable_app/lib/models/user_model.dart
+++ b/Software/wearable_app/lib/models/user_model.dart
@@ -6,6 +6,7 @@ class UserModel {
   final Map<String, CaloriesByHeartRateEntry> caloriesByHeartRate;
   final Map<String, Spo2Entry> spo2;
   LatestSpO2 latestSpO2;
+  LatestHeartRate latestHeartRate;
   final Map<String, AccelerometerCaloriesEntry> caloriesByAccelerometer;
   final Map<String, GpsEntry> gps;
   late final LatestLocation latestLocation;
@@ -18,6 +19,7 @@ class UserModel {
     required this.caloriesByHeartRate,
     required this.spo2,
     required this.latestSpO2,
+    required this.latestHeartRate,
     required this.caloriesByAccelerometer,
     required this.gps,
     required this.latestLocation,
@@ -44,7 +46,10 @@ class UserModel {
           ) ??
           {},
       latestSpO2: LatestSpO2.fromJson(
-        json['latest_in4'] as Map<String, dynamic>? ?? {},
+        json['latest_spo2'] as Map<String, dynamic>? ?? {},
+      ),
+      latestHeartRate: LatestHeartRate.fromJson(
+        json['latest_heart_rate'] as Map<String, dynamic>? ?? {},
       ),
       caloriesByAccelerometer:
           (json['calorise_by_accelerometer'] as Map<String, dynamic>?)?.map(
@@ -84,6 +89,7 @@ class UserModel {
     ),
     'spo2': spo2.map((k, v) => MapEntry(k, v.toJson())),
     'latest_spo2': latestSpO2.toJson(),
+    'latest_heart_rate': latestHeartRate.toJson(),
     'calorise_by_accelerometer': caloriesByAccelerometer.map(
       (k, v) => MapEntry(k, v.toJson()),
     ),
@@ -150,6 +156,25 @@ class LatestSpO2 {
   }
 
   Map<String, dynamic> toJson() => {'percentage': percentage};
+}
+
+class LatestHeartRate {
+  final num bpm;
+  final String timestamp;
+
+  LatestHeartRate({required this.bpm, this.timestamp = ''});
+
+  factory LatestHeartRate.fromJson(Map<String, dynamic> json) {
+    return LatestHeartRate(
+      bpm: json['bpm'] as num? ?? 0,
+      timestamp: json['timestamp'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'bpm': bpm,
+        'timestamp': timestamp,
+      };
 }
 
 class AccelerometerCaloriesEntry {

--- a/Software/wearable_app/lib/screens/home_screen/home_screen.dart
+++ b/Software/wearable_app/lib/screens/home_screen/home_screen.dart
@@ -66,7 +66,7 @@ class _HomeScreenState extends State<HomeScreen> {
     super.initState();
     // Listen to scan results and update UI
     // Listen latest heart rate
-    FirebaseService().listenToChanges('users/$_userId/latest_in4').listen((
+    FirebaseService().listenToChanges('users/$_userId/latest_heart_rate').listen((
       event,
     ) {
       final raw = event.snapshot.value;
@@ -76,7 +76,7 @@ class _HomeScreenState extends State<HomeScreen> {
     });
 
     // Listen latest SpO2
-    FirebaseService().listenToChanges('users/$_userId/latest_in4').listen((
+    FirebaseService().listenToChanges('users/$_userId/latest_spo2').listen((
       event,
     ) {
       final raw = event.snapshot.value;


### PR DESCRIPTION
## Summary
- store latest HR and SpO2 under paths expected by clients
- add `LatestHeartRate` dataclass and expose in `UserData`
- parse `latest_heart_rate` in `BaseService`
- **update wearable app to read new database paths**

## Testing
- `pytest -q` *(fails: ImportError for paho.mqtt.client)*

------
https://chatgpt.com/codex/tasks/task_e_6840e0f3913c83208ea46a4a2ea4cb7c