### PR TITLE
Add sleep status tracking

### DIFF
--- a/Software/server_project/db/base.py
+++ b/Software/server_project/db/base.py
@@ -118,8 +118,10 @@ class BaseService:
     def add_sleep_record(self, user_id: str, start_time: str, end_time: str, duration_hours: float) -> None:
         update_sleep_record(user_id, start_time, end_time, duration_hours)
 
-    def add_daily_sleep(self, user_id: str, date: str, sleep_duration: float) -> None:
-        update_daily_sleep(user_id, date, sleep_duration)
+    def add_daily_sleep(
+        self, user_id: str, date: str, sleep_duration: float, is_sleeping: bool
+    ) -> None:
+        update_daily_sleep(user_id, date, sleep_duration, is_sleeping)
 
 # Example Usage
 if __name__ == '__main__':

--- a/Software/server_project/db/firebase_manager.py
+++ b/Software/server_project/db/firebase_manager.py
@@ -129,12 +129,16 @@ def update_sleep_record(user_id: str, start_time: str, end_time: str, duration_h
     })
 
 
-def update_daily_sleep(user_id: str, date: str, sleep_duration: float) -> None:
+def update_daily_sleep(
+    user_id: str, date: str, sleep_duration: float, is_sleeping: bool
+) -> None:
     """
-    Write total sleep duration for a specific date.
+    Write total sleep duration for a specific date and current sleeping state.
     """
     path = f"users/{user_id}/daily_sleep/{date}"
-    get_reference(path).set({'sleep_duration': sleep_duration})
+    get_reference(path).set(
+        {"sleep_duration": sleep_duration, "is_sleeping": is_sleeping}
+    )
 
 
 # Example usage
@@ -149,5 +153,5 @@ if __name__ == '__main__':
     update_gps('user123', '2025-04-22T18:00:00', 21.0278, 105.8342, 12.0)
     update_latest_location('user123', 21.0278, 105.8342, 12.0, '2025-04-22T18:00:00')
     update_sleep_record('user123', '2025-04-21T22:00:00', '2025-04-22T06:00:00', 8.0)
-    update_daily_sleep('user123', '2025-04-22', 8.0)
+    update_daily_sleep('user123', '2025-04-22', 8.0, False)
     update_calories_daily('user123', '2025-04-22', 750.7, 300.5, 450.2)

--- a/Software/server_project/db/models.py
+++ b/Software/server_project/db/models.py
@@ -54,6 +54,7 @@ class SleepRecord:
 @dataclass
 class DailySleep:
     sleep_duration: float
+    is_sleeping: bool = False
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/Software/server_project/mqtt/mqtt_server.py
+++ b/Software/server_project/mqtt/mqtt_server.py
@@ -79,6 +79,7 @@ def on_message(client, userdata, msg):
             is_sleeping = True
             sleep_start_time = datetime.fromisoformat(timestamp)
             print(f"Sleep detected at {sleep_start_time}")
+            service.add_daily_sleep(user_id, today, duration_h, True)
         elif bpm > 70 and is_sleeping:
             is_sleeping = False
             end_time = datetime.fromisoformat(timestamp)
@@ -95,6 +96,7 @@ def on_message(client, userdata, msg):
                 user_id,
                 today,
                 duration_h,
+                False,
             )
         if today_pr != today:
             is_new_day = True

--- a/Software/wearable_app/lib/core/utils/process_data.dart
+++ b/Software/wearable_app/lib/core/utils/process_data.dart
@@ -108,7 +108,8 @@ class ProcessDataService {
       durationHours: durationHours,
     );
     final date = startTime.substring(0, 10);
-    user.dailySleep[date] = DailySleep(sleepDuration: durationHours);
+    user.dailySleep[date] =
+        DailySleep(sleepDuration: durationHours, isSleeping: false);
     await _saveUser(user);
   }
 

--- a/Software/wearable_app/lib/models/user_model.dart
+++ b/Software/wearable_app/lib/models/user_model.dart
@@ -275,16 +275,21 @@ class SleepSession {
 
 class DailySleep {
   final double sleepDuration;
+  final bool isSleeping;
 
-  DailySleep({required this.sleepDuration});
+  DailySleep({required this.sleepDuration, required this.isSleeping});
 
   factory DailySleep.fromJson(Map<String, dynamic> json) {
     return DailySleep(
       sleepDuration: (json['sleep_duration'] as num).toDouble(),
+      isSleeping: (json['is_sleeping'] as bool? ?? false),
     );
   }
 
-  Map<String, dynamic> toJson() => {'sleep_duration': sleepDuration};
+  Map<String, dynamic> toJson() => {
+        'sleep_duration': sleepDuration,
+        'is_sleeping': isSleeping,
+      };
 }
 
 class DailyCalories {

--- a/Software/wearable_app/lib/screens/home_screen/home_screen.dart
+++ b/Software/wearable_app/lib/screens/home_screen/home_screen.dart
@@ -57,6 +57,7 @@ class _HomeScreenState extends State<HomeScreen> {
   double _spo2 = 0.0;
   double _calories = 0.0;
   double _sleepHours = 0.0;
+  bool _isSleeping = false;
 
   double _latitude = 0.0;
   double _longitude = 0.0;
@@ -105,10 +106,14 @@ class _HomeScreenState extends State<HomeScreen> {
         .listenToChanges('users/$_userId/daily_sleep/$today')
         .listen((event) {
           final raw = event.snapshot.value;
-          if (raw is Map && raw['sleep_duration'] != null) {
-            setState(
-              () => _sleepHours = (raw['sleep_duration'] as num).toDouble(),
-            );
+          if (raw is Map) {
+            if (raw['sleep_duration'] != null) {
+              _sleepHours = (raw['sleep_duration'] as num).toDouble();
+            }
+            if (raw['is_sleeping'] != null) {
+              _isSleeping = raw['is_sleeping'] as bool;
+            }
+            setState(() {});
           }
         });
 
@@ -272,14 +277,19 @@ class _HomeScreenState extends State<HomeScreen> {
                           ),
                           const SizedBox(height: 4),
                           Text(
-                            _formatSleep(_sleepHours),
-                            style: const TextStyle(fontSize: 16),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
+                          _formatSleep(_sleepHours),
+                          style: const TextStyle(fontSize: 16),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          _isSleeping ? 'Đang ngủ' : 'Đã thức',
+                          style: const TextStyle(fontSize: 14),
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
+              ),
               ),
               const SizedBox(height: 16),
 


### PR DESCRIPTION
## Summary
- track current sleep status in Firebase
- display sleep status on wearable home screen

## Testing
- `python -m py_compile Software/server_project/db/firebase_manager.py Software/server_project/db/base.py Software/server_project/db/models.py Software/server_project/mqtt/mqtt_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6840ee12c0f4832094289af6260dfb90