### PR TITLE
Add sleep start time support

### DIFF
--- a/Software/server_project/db/base.py
+++ b/Software/server_project/db/base.py
@@ -119,9 +119,20 @@ class BaseService:
         update_sleep_record(user_id, start_time, end_time, duration_hours)
 
     def add_daily_sleep(
-        self, user_id: str, date: str, sleep_duration: float, is_sleeping: bool
+        self,
+        user_id: str,
+        date: str,
+        sleep_duration: float,
+        is_sleeping: bool,
+        sleep_start_time: Optional[str] | None = None,
     ) -> None:
-        update_daily_sleep(user_id, date, sleep_duration, is_sleeping)
+        update_daily_sleep(
+            user_id,
+            date,
+            sleep_duration,
+            is_sleeping,
+            sleep_start_time,
+        )
 
 # Example Usage
 if __name__ == '__main__':

--- a/Software/server_project/db/firebase_manager.py
+++ b/Software/server_project/db/firebase_manager.py
@@ -130,15 +130,27 @@ def update_sleep_record(user_id: str, start_time: str, end_time: str, duration_h
 
 
 def update_daily_sleep(
-    user_id: str, date: str, sleep_duration: float, is_sleeping: bool
+    user_id: str,
+    date: str,
+    sleep_duration: float,
+    is_sleeping: bool,
+    sleep_start_time: Optional[str] | None = None,
 ) -> None:
     """
     Write total sleep duration for a specific date and current sleeping state.
+    Optionally store ``sleep_start_time`` when the user is currently sleeping.
     """
     path = f"users/{user_id}/daily_sleep/{date}"
-    get_reference(path).set(
-        {"sleep_duration": sleep_duration, "is_sleeping": is_sleeping}
-    )
+    data = {"sleep_duration": sleep_duration, "is_sleeping": is_sleeping}
+    if sleep_start_time is not None:
+        data["sleep_start_time"] = sleep_start_time
+    get_reference(path).set(data)
+
+
+def fetch_daily_sleep(user_id: str, date: str) -> Optional[Dict[str, Any]]:
+    """Return the raw ``daily_sleep`` entry for ``date`` if present."""
+    path = f"users/{user_id}/daily_sleep/{date}"
+    return get_reference(path).get()
 
 
 # Example usage

--- a/Software/server_project/db/models.py
+++ b/Software/server_project/db/models.py
@@ -55,6 +55,7 @@ class SleepRecord:
 class DailySleep:
     sleep_duration: float
     is_sleeping: bool = False
+    sleep_start_time: Optional[str] = None
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/Software/server_project/test/create_example.py
+++ b/Software/server_project/test/create_example.py
@@ -59,7 +59,9 @@ def generate_sample_data(user_id: str, days: int = 10):
         # daily_sleep: tổng số giờ ngủ trong ngày
         sleep_duration = round(random.uniform(5, 8), 2)
         ref.child('daily_sleep').child(date_str).set({
-            'sleep_duration': sleep_duration
+            'sleep_duration': sleep_duration,
+            'is_sleeping': False,
+            'sleep_start_time': None,
         })
 
         # === SLEEP: 1 bản ghi mỗi ngày ===

--- a/Software/wearable_app/lib/models/user_model.dart
+++ b/Software/wearable_app/lib/models/user_model.dart
@@ -276,19 +276,26 @@ class SleepSession {
 class DailySleep {
   final double sleepDuration;
   final bool isSleeping;
+  final String? sleepStartTime;
 
-  DailySleep({required this.sleepDuration, required this.isSleeping});
+  DailySleep({
+    required this.sleepDuration,
+    required this.isSleeping,
+    this.sleepStartTime,
+  });
 
   factory DailySleep.fromJson(Map<String, dynamic> json) {
     return DailySleep(
       sleepDuration: (json['sleep_duration'] as num).toDouble(),
       isSleeping: (json['is_sleeping'] as bool? ?? false),
+      sleepStartTime: json['sleep_start_time'] as String?,
     );
   }
 
   Map<String, dynamic> toJson() => {
         'sleep_duration': sleepDuration,
         'is_sleeping': isSleeping,
+        if (sleepStartTime != null) 'sleep_start_time': sleepStartTime,
       };
 }
 


### PR DESCRIPTION
## Summary
- track `sleep_start_time` in server project
- initialize server with existing sleep start time
- update MQTT server to store start time when sleeping
- extend DailySleep models for new field
- display active sleep status in wearable app
- load today's sleep duration on server startup

## Testing
- `python3 -m py_compile Software/server_project/db/firebase_manager.py Software/server_project/db/base.py Software/server_project/db/models.py Software/server_project/mqtt/mqtt_server.py Software/server_project/test/create_example.py`

------
https://chatgpt.com/codex/tasks/task_e_6840fb7a053c8320918db436c72bfa3d